### PR TITLE
A little fix for adding decorative image alt=""

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -45,4 +45,4 @@
 	{{ else }}
 	src="{{ $src.Permalink }}" 
 	{{ end }}
-	{{ with .Get "alt" }}alt='{{.}}'{{ end }}>
+	{{- with .Get "alt" -}}alt="{{.}}"{{ else }}alt=""{{- end -}}


### PR DESCRIPTION
A small patch to add a decorative image alt="" correctly generate in Hugo